### PR TITLE
dts: Add mdio and phy node to Ethernet configuration

### DIFF
--- a/boards/catie/zest_core_stm32h753zi/zest_core_stm32h753zi.dts
+++ b/boards/catie/zest_core_stm32h753zi/zest_core_stm32h753zi.dts
@@ -316,6 +316,8 @@
 		     &eth_txd0_pb12
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -323,7 +325,7 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
 		status = "okay";


### PR DESCRIPTION
This pull request updates the device tree source file for the `zest_core_stm32h753zi` board to configure the Ethernet PHY connection for Zephyr 4.2.0 compatibility. The most important changes include specifying the PHY connection type, adding a handle for the Ethernet PHY, and add phy label.

Cf: https://github.com/zephyrproject-rtos/zephyr/commit/d74d0f7ac77a39abfaa6741a6b976d54b9dfd22d

### Ethernet configuration updates:
* [`boards/catie/zest_core_stm32h753zi/zest_core_stm32h753zi.dts`](diffhunk://#diff-0bd097c8839a22b5aa8364fd257dd3a7cea791ffaccc6a26f4a559476fd53d62R319-R328): Added `phy-connection-type` as "rmii" and a `phy-handle` pointing to the Ethernet PHY to define the connection type and reference the PHY node.
* [`boards/catie/zest_core_stm32h753zi/zest_core_stm32h753zi.dts`](diffhunk://#diff-0bd097c8839a22b5aa8364fd257dd3a7cea791ffaccc6a26f4a559476fd53d62R319-R328): Add label for the Ethernet PHY node `eth_phy: ethernet-phy@0`.