### PR TITLE
Use STM32_CLOCK macro

### DIFF
--- a/boards/catie/zest_core_stm32h753zi/zest_core_stm32h753zi.dts
+++ b/boards/catie/zest_core_stm32h753zi/zest_core_stm32h753zi.dts
@@ -334,7 +334,7 @@
 
 /* on sixtron connector 2 */
 &fdcan1 {
-	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
 		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
@@ -345,7 +345,7 @@
 
 /* on sixtron connector 1 */
 &fdcan2 {
-	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
 		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	pinctrl-0 = <&fdcan2_rx_pb5 &fdcan2_tx_pb6>;
 	pinctrl-names = "default";


### PR DESCRIPTION
This pull request makes a small update to the clock configuration for `fdcan1` and `fdcan2` peripherals in the device tree file. The change refactors the way the clock is specified to use the newer `STM32_CLOCK` macro for improved clarity and consistency.

Clock configuration updates:

* Updated the `clocks` property for `fdcan1` to use the `STM32_CLOCK(APB1_2, 8)` macro instead of `STM32_CLOCK_BUS_APB1_2 0x00000100` in `zest_core_stm32h753zi.dts`.
* Updated the `clocks` property for `fdcan2` to use the `STM32_CLOCK(APB1_2, 8)` macro instead of `STM32_CLOCK_BUS_APB1_2 0x00000100` in `zest_core_stm32h753zi.dts`.

For more information: https://github.com/zephyrproject-rtos/zephyr/commit/f3e5644f662b2530fc639a43856a5840e49105ab